### PR TITLE
Fix invalid indentation in LoadTextureWithMips

### DIFF
--- a/src/easygl/utils.nim
+++ b/src/easygl/utils.nim
@@ -83,7 +83,7 @@ proc LoadTextureWithMips*(path:string, gammaCorrection:bool = false) : TextureId
                 (gammaFormat,PixelDataFormat.RGBA,GL_CLAMP_TO_EDGE)
             else:            
                 ( echo "texture unknown, assuming rgb";        
-                (TextureInternalFormat.RGB,PixelDataFormat.RGB,GL_REPEAT) )
+                       (TextureInternalFormat.RGB,PixelDataFormat.RGB,GL_REPEAT) )
                 
         TexImage2D(TexImageTarget.TEXTURE_2D,
                    0'i32,


### PR DESCRIPTION
I'm using easygl in a small project of mine and I ran into an indentation error:

```
        ... /home/sam/.nimble/pkgs/easygl-0.1.0/easygl/utils.nim(86, 17) Error: invalid indentation
```

I went ahead and fixed it. 